### PR TITLE
Updated base path for Symbl Summary

### DIFF
--- a/src/api/fetchSummary.js
+++ b/src/api/fetchSummary.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export const getSummary = async (conversationId, token) => {
   return axios.get(
-    `https://api-labs.symbl.ai/v1/conversations/${conversationId}/summary`,
+    `https://api.symbl.ai/v1/conversations/${conversationId}/summary`,
     {
       headers: {
         Authorization: `Bearer ${token}`,

--- a/src/hooks/useSymblai.js
+++ b/src/hooks/useSymblai.js
@@ -33,7 +33,7 @@ export function useSymblai({ publisher, isPublishing }) {
         setSymblToken(response.data.accessToken);
         symbl.init({
           accessToken: response.data.accessToken, // can be used instead of appId and appSecret
-          basePath: 'https://api-labs.symbl.ai',
+          basePath: 'https://api.symbl.ai',
         });
       })
       .catch((e) => console.log(e));


### PR DESCRIPTION
[Symbl's summarisation](https://docs.symbl.ai/docs/conversation-api/summary/) has been Alpha released and is now available from the base path "api.symbl.ai". 